### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
           gcr.io/kaniko-project/executor:latest
     
     - name: Sign images 
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@4079ad3567a89f68395480299c77e40170430341 #main
       with:
         cosign-release: 'v0.2.0'
     
@@ -148,7 +148,7 @@ jobs:
           gcr.io/kaniko-project/executor:debug
 
     - name: Sign images 
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@4079ad3567a89f68395480299c77e40170430341 #main
       with:
         cosign-release: 'v0.2.0'
       
@@ -216,7 +216,7 @@ jobs:
           gcr.io/kaniko-project/warmer:latest
 
     - name: Sign images 
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@4079ad3567a89f68395480299c77e40170430341 #main
       with:
         cosign-release: 'v0.2.0'
 


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
